### PR TITLE
ignore bridge methods in generified use cases

### DIFF
--- a/core/src/main/java/com/envimate/messageMate/useCases/useCaseAdapter/usecaseCalling/SinglePublicUseCaseMethodCaller.java
+++ b/core/src/main/java/com/envimate/messageMate/useCases/useCaseAdapter/usecaseCalling/SinglePublicUseCaseMethodCaller.java
@@ -30,10 +30,12 @@ import lombok.RequiredArgsConstructor;
 import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static com.envimate.messageMate.internal.reflections.ForbiddenUseCaseMethods.NOT_ALLOWED_USECASE_PUBLIC_METHODS;
 import static com.envimate.messageMate.internal.reflections.ReflectionUtils.getAllPublicMethods;
 import static com.envimate.messageMate.useCases.useCaseAdapter.methodInvoking.SerializingMethodInvoker.serializingMethodInvoker;
+import static java.util.function.Predicate.not;
 import static lombok.AccessLevel.PRIVATE;
 
 /**
@@ -59,8 +61,11 @@ public final class SinglePublicUseCaseMethodCaller<U> implements Caller<U> {
         return new SinglePublicUseCaseMethodCaller<>(methodInvoker);
     }
 
-    private static Method locateUseCaseMethod(final Class<?> useCaseClass) {
-        final List<Method> useCaseMethods = getAllPublicMethods(useCaseClass, NOT_ALLOWED_USECASE_PUBLIC_METHODS);
+    static Method locateUseCaseMethod(final Class<?> useCaseClass) {
+        final List<Method> useCaseMethods =
+                getAllPublicMethods(useCaseClass, NOT_ALLOWED_USECASE_PUBLIC_METHODS).stream()
+                .filter(not(Method::isBridge))
+                .collect(Collectors.toList());
         if (useCaseMethods.size() == 1) {
             return useCaseMethods.get(0);
         } else {

--- a/core/src/test/java/com/envimate/messageMate/useCases/useCaseAdapter/usecaseCalling/GenericMethodInterface.java
+++ b/core/src/test/java/com/envimate/messageMate/useCases/useCaseAdapter/usecaseCalling/GenericMethodInterface.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2019 envimate GmbH - https://envimate.com/.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.envimate.messageMate.useCases.useCaseAdapter.usecaseCalling;
+
+public interface GenericMethodInterface<I, O> {
+    O invoke(I request);
+}

--- a/core/src/test/java/com/envimate/messageMate/useCases/useCaseAdapter/usecaseCalling/GenericMethodUseCase.java
+++ b/core/src/test/java/com/envimate/messageMate/useCases/useCaseAdapter/usecaseCalling/GenericMethodUseCase.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2019 envimate GmbH - https://envimate.com/.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.envimate.messageMate.useCases.useCaseAdapter.usecaseCalling;
+
+public class GenericMethodUseCase implements GenericMethodInterface<String, String> {
+    @Override
+    public String invoke(final String in) {
+        return in.replace("in", "out");
+    }
+}

--- a/core/src/test/java/com/envimate/messageMate/useCases/useCaseAdapter/usecaseCalling/SinglePublicUseCaseMethodCallerTest.java
+++ b/core/src/test/java/com/envimate/messageMate/useCases/useCaseAdapter/usecaseCalling/SinglePublicUseCaseMethodCallerTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2019 envimate GmbH - https://envimate.com/.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.envimate.messageMate.useCases.useCaseAdapter.usecaseCalling;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class SinglePublicUseCaseMethodCallerTest {
+    @Test
+    void locatesGenericMethods_aka_ignoresBridgeMethods() throws Exception {
+        final Method actualMethod = SinglePublicUseCaseMethodCaller.locateUseCaseMethod(GenericMethodUseCase.class);
+        final Method expectedMethod = GenericMethodUseCase.class.getMethod("invoke", String.class);
+        assertEquals(expectedMethod, actualMethod, "located method");
+    }
+}


### PR DESCRIPTION
When I use a generified use case:

```java
public interface GenericMethodInterface<I, O> {
    O invoke(I request);
}

public class GenericMethodUseCase implements GenericMethodInterface<String, String> {
    @Override
    public String invoke(final String in) {
        return in.replace("in", "out");
    }
}
```

I can't (no pun intended) use it. The use-case method lookup logic in `SinglePublicUseCaseMethodCaller` sees two methods

- The generic method
- The bridge method associated with the generic method ([whassat?](https://stas-blogspot.blogspot.com/2010/03/java-bridge-methods-explained.html), [wait, what?](https://docs.oracle.com/javase/tutorial/java/generics/bridgeMethods.html))

And throws the exception:

```text
java.lang.IllegalArgumentException: Use case classes must have 1 instance method.
Found the methods[
public java.lang.String pkg.GenericMethodUseCase.invoke(java.lang.String),
public java.lang.Object pkg.GenericMethodUseCase.invoke(java.lang.Object)
]for class class pkg.GenericMethodUseCase
```

The fix is simple, but for the life of me, the test suite is so complex I could not write
a test in the same style as what exists there already.

Instead I added a shim by making a production method package-private and calling
that method directly from a simple unit test.