### PR TITLE
use non-clashing core jar name across mapmate, messagemate, httpmate

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -91,4 +91,7 @@
         </dependencies>
     </dependencyManagement>
 
+    <build>
+        <finalName>messagemate-core-${project.version}</finalName>
+    </build>
 </project>


### PR DESCRIPTION
In the absence of module-info.java and `Automatic-Module-Name` in the `MANIFEST.MF`,
the jar name part before the version string will determine what module name
a jar is imported as in a modularized java application.

mapmate core, httpmate core, message core all use `core-x.y.z.jar` as jar filename.
So they can't be loaded in a modularized java application because their automatically
derived module name clashes.

`Automatic-Module-Name` Derivation is not handled by the javadoc command correctly (as Richard reported):

```text
Exit code: 1 - error: cannot determine module name for /home/richard/projects/envimate/opensource/message-mate/core/target/core-1.0.9.jar
[ERROR] 
[ERROR] Command line was: /home/richard/apps/java/installed_versions/jdk-11.0.4+11/bin/javadoc @options @packages
[ERROR] 
[ERROR] Refer to the generated Javadoc files in '/home/richard/projects/envimate/opensource/message-mate/core/target/apidocs' dir
```

so the last resort is to assign a module name is to change the jar file name of the maven artifact.

As mentioned on <https://blog.joda.org/2017/05/java-se-9-jpms-automatic-modules.html>

> The final missing piece of information is the module name. This has been a big point of discussion in Project Jigsaw. As it stands, the module name will be derived from the filename of the jar file. For me, this is a critical problem with the basic design of automatic modules (but see the mitigation section below). 

SO we're left with the jar file name modification to avoid clashes.

This PR fixes that for this project.

This is no guarantee that loading the modules will succeed, but at the very least, it will enable me to go one step further, and see what the next problem is, if any.